### PR TITLE
Remove platformPackages config

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,16 +120,6 @@
     "typescript": "^4.4.3",
     "vsce": "^2.14.0"
   },
-  "config": {
-    "platformPackages": {
-      "url": "@PLATFORM_PACKAGE_URL@",
-      "platforms": {
-        "linux": "kubescape-ubuntu-latest",
-        "darwin": "kubescape-macos-latest",
-        "win32": "kubescape-windows-latest"
-      }
-    }
-  },
   "dependencies": {
     "@kubescape/yamlparse": "^0.1.0",
     "@kubescape/install": "^0.4.2",


### PR DESCRIPTION
I'm not sure whether the platformPackages config is still needed here.

- https://github.com/kubescape/kubescape/pull/1213

Since we are adding the arm64 binaries support, if it's still needed, maybe we shall find a way to represent those arm64 binaries as well.

