### PR TITLE
Bump kubescape version into v2.3.1

### DIFF
--- a/src/Kubescape/globals.ts
+++ b/src/Kubescape/globals.ts
@@ -1,3 +1,3 @@
-export const PACKAGE_STABLE_BUILD = "v2.0.176";
+export const PACKAGE_STABLE_BUILD = "v2.3.1";
 export const ERROR_KUBESCAPE_NOT_INSTALLED = "Kubescape is not installed!";
 export const COMMAND_VIEW_CTRL_DOC = "kubescape.viewCtrlDoc";


### PR DESCRIPTION
Tested when combined with https://github.com/kubescape/node-kubescape/pull/3 , scanning and error reporting are all OK.

![image](https://user-images.githubusercontent.com/43995067/236306706-334b55b4-e539-4be3-9e72-b26fb24393c9.png)
![image](https://user-images.githubusercontent.com/43995067/236306822-339b4f2d-26d4-4685-8fea-6c7a0ef02d26.png)
