### PR TITLE
feat: removed node-yamlParse dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache",
       "dependencies": {
         "@kubescape/install": "^0.4.2",
-        "@kubescape/yamlparse": "^0.1.0",
         "abort-controller": "^3.0.0",
         "jsdom": "^19.0.0",
         "node-fetch": "^2.6.0"
@@ -234,11 +233,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/@kubescape/yamlparse": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@kubescape/yamlparse/-/yamlparse-0.1.0.tgz",
-      "integrity": "sha512-jlmQZKTUaWPbj9h9pbFPRInmMo0t/u+Bc/hd8BRKCn9BEALUTeRWM2bUUXNt2/6GXekQvTTCoC4hEvTzx0xg6g=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4723,11 +4717,6 @@
           }
         }
       }
-    },
-    "@kubescape/yamlparse": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@kubescape/yamlparse/-/yamlparse-0.1.0.tgz",
-      "integrity": "sha512-jlmQZKTUaWPbj9h9pbFPRInmMo0t/u+Bc/hd8BRKCn9BEALUTeRWM2bUUXNt2/6GXekQvTTCoC4hEvTzx0xg6g=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "vsce": "^2.14.0"
   },
   "dependencies": {
-    "@kubescape/yamlparse": "^0.1.0",
     "@kubescape/install": "^0.4.2",
     "abort-controller": "^3.0.0",
     "jsdom": "^19.0.0",

--- a/src/Kubescape/scan.ts
+++ b/src/Kubescape/scan.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { YamlHighlighter } from '@kubescape/yamlparse';
+import { YamlHighlighter } from './yamlParse';
 import { KubescapeApi } from '@kubescape/install';
 
 import { VscodeUi } from '../utils/ui';

--- a/src/Kubescape/yamlParse.ts
+++ b/src/Kubescape/yamlParse.ts
@@ -14,7 +14,7 @@ function checkAndUpdateIndent(startIndexAcc : StartIndexAccType, index : number)
   }
 }
 
-export class ResourceHighlightsHelperService {
+export class YamlHighlighter {
 
   static splitPathToSteps(path: string): string[] {
     const splitRegExp = new RegExp(/[a-zA-Z]+|\[[^[]+]/, 'g');
@@ -33,9 +33,9 @@ export class ResourceHighlightsHelperService {
   }
 
   static getStartAndEndIndexes(steps: string[], lines: string[]): IYamlHighlight {
-    const startIndexAcc = ResourceHighlightsHelperService.getStartIndexAcc(steps, lines);
+    const startIndexAcc = YamlHighlighter.getStartIndexAcc(steps, lines);
     const startIndex = startIndexAcc.startIndex;
-    const endIndex = ResourceHighlightsHelperService.getEndIndex(startIndex, lines, !!startIndexAcc.tempMatch);
+    const endIndex = YamlHighlighter.getEndIndex(startIndex, lines, !!startIndexAcc.tempMatch);
 
     return { startIndex, endIndex };
   }


### PR DESCRIPTION
**What does the PR do ?**
Currently the VS-Code extension uses [node-yamlParse](https://github.com/kubescape/node-yamlparse) module for parsing the YAML file based on path. The same features and functionalities are present in the repo itself under the file `yamlParse.ts`. So, alternatively we can use this file for providing functions  for parsing YAML file.

**Benifits**
- If any change is needed in functions related to YAML parsing, it can be made directly inside this `VS-Code Extension` repo itself.
- By using the `yamlParse.ts` , we would remove the dependency on the node-module and it would help contributors to contribute directly on the VS-Code repository.

