### PR TITLE
fix: correct typo occured to occurred in error comment

### DIFF
--- a/src/Kubescape/scan/scan.ts
+++ b/src/Kubescape/scan/scan.ts
@@ -44,7 +44,7 @@ export async function kubescapeScanDocument(document: vscode.TextDocument, displ
 
     }catch(err: any){
         Logger.error(err.message, true);
-        // Update panel with Error message. Some error occured while scanning
+        // Update panel with Error message. Some error occurred while scanning
         
     } finally {
         Logger.info('------------------------------------------------_Scan Completed_------------------------------------------------');


### PR DESCRIPTION
Fixes a typo in the inline comment for the catch-block in `scan.ts` ('occured' -> 'occurred').

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor improvement to code documentation with spelling correction. No impact on user-facing functionality or behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/vscode-kubescape/pull/26)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->